### PR TITLE
Add autoload cookie to auto-mode-alist

### DIFF
--- a/racket-mode.el
+++ b/racket-mode.el
@@ -1722,6 +1722,7 @@ All commands in `lisp-mode-shared-map' are inherited by this map.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Files
 
+;;;###autoload
 (setq auto-mode-alist
       (append '(("\\.rkt\\'" . racket-mode)
                 ("\\.rktd\\'" . racket-mode))


### PR DESCRIPTION
This commit ensures that users who have installed `racket-mode` from a MELPA package will be able to automatically turn on `racket-mode` when visiting a `rkt` or `rktd` file without explicitly requiring the library first.
