### PR TITLE
Delete paren-face customization.

### DIFF
--- a/racket-mode.el
+++ b/racket-mode.el
@@ -271,7 +271,8 @@ To run <file>'s `test` submodule."
 
 (defconst racket-paren-face 'racket-paren-face)
 (defface racket-paren-face
-  '((t (:foreground "gray30" )))
+  (let ((fg (face-foreground 'default)))
+    `((t (:foreground ,fg))))
   "Face for parentheses () [] {}"
   :group 'racket)
 


### PR DESCRIPTION
Delete paren-face customization. 

I am using a theme with a light background and the parens are nearly invincible when set to color "honeydew4". I know how to customize this, but everyone using a light but not white background would have to do so.

Please see this 
![screenshot](https://f.cloud.github.com/assets/2273210/1681335/18e64286-5d91-11e3-8045-8c8210cbed5a.png) 
it is especially hard to distinguish at first glance between ( and [ .
