### PR TITLE
Add autoload cookie to racket-mode

### DIFF
--- a/racket-mode.el
+++ b/racket-mode.el
@@ -1793,6 +1793,7 @@ All commands in `lisp-mode-shared-map' are inherited by this map.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;;###autoload
 (define-derived-mode racket-mode scheme-mode
   "Racket"
   "Major mode for editing Racket.


### PR DESCRIPTION
Adding autoload cookie to `raket-mode` function is needed to automatically turn on `racket-mode` too.

Sorry for previous patch is not enough.

Re: greghendershott/racket-mode/pull/5
