### PR TITLE
Fix racket-sandbox-rkt for developing racket-mode

### DIFF
--- a/racket-mode.el
+++ b/racket-mode.el
@@ -1843,7 +1843,7 @@ Defaults to a regexp ignoring all inputs of 0, 1, or 2 letters."
       (buffer-substring (point) end))))
 
 (defvar racket-sandbox-rkt
-  (let ((elisp-dir (file-name-directory load-file-name)))
+  (let ((elisp-dir (file-name-directory (or load-file-name (buffer-file-name)))))
     (expand-file-name "sandbox.rkt" elisp-dir))
   "Path to sandbox.rkt")
 


### PR DESCRIPTION
This patch is useful for developing `racket-mode.el`. If `racket-sandbox-rkt` is evaluated by `eval-buffer`, The value of `racket-sandbox-rkt` is constructed from `buffer-file-name`.
