### PR TITLE
Use cl-lib macro instead of cl

### DIFF
--- a/racket-complete.el
+++ b/racket-complete.el
@@ -78,7 +78,7 @@ See `racket--invalidate-completion-cache' and
   '(progn
      (defun racket-company-backend (command &optional arg &rest ignore)
        (interactive (list 'interactive))
-       (case command
+       (cl-case command
          ('interactive (company-begin-backend 'racket-company-backend))
          ('prefix (racket--company-prefix))
          ('candidates (racket--company-candidates


### PR DESCRIPTION
Because racket-mode uses `cl-lib.el`, not `cl.el`.
