### PR TITLE
delete-trailing-whitespace in racket-newline-and-indent

### DIFF
--- a/racket-common.el
+++ b/racket-common.el
@@ -457,6 +457,7 @@ existence using `fboundp'."
 (defun racket-newline-and-indent ()
   "Do `newline' and `racket-indent-line'."
   (interactive)
+  (delete-trailing-whitespace)
   (newline)
   (racket-indent-line))
 


### PR DESCRIPTION
Avoids ugly trailing whitespace in empty lines inserted by RET