### PR TITLE
Bind C-c C-c to #'racket-run

### DIFF
--- a/racket-mode.el
+++ b/racket-mode.el
@@ -56,6 +56,7 @@ http://www.gnu.org/licenses/ for details.")
 (defvar racket-mode-map
   (racket--easy-keymap-define
    '(("C-c C-k"     racket-run)
+     ("C-c C-c"     racket-run)
      ("C-c C-z"     racket-repl)
      ("<f5>"        racket-run-and-switch-to-repl)
      ("M-C-<f5>"    racket-racket)


### PR DESCRIPTION
This is in line with the practice of other major modes, like
python-mode. Some other modes (like haskell-mode) use this to map to a
mode-specific version of #'compile, but I'm not sure that this would be
too relevant here. What do you think?