### PR TITLE
Fix condition around save-buffer in racket--do-run

### DIFF
--- a/racket-edit.el
+++ b/racket-edit.el
@@ -97,7 +97,8 @@ Others are available only as a command in the REPL.
 Supplies CONTEXT-LEVEL to the back-end ,run command; see run.rkt."
   (unless (eq major-mode 'racket-mode)
     (error "Current buffer is not a racket-mode buffer"))
-  (when (buffer-modified-p)
+  (when (or (buffer-modified-p)
+            (and buffer-file-name (not (file-exists-p buffer-file-name))))
     (save-buffer))
   (remove-overlays (point-min) (point-max) 'racket-uncovered-overlay)
   (racket--invalidate-completion-cache)


### PR DESCRIPTION
It's not enough to check if a file has been modified; the underlying
file could have been deleted, or the buffer could have never been
saved (it could have been generated by a command, or it could be an
empty buffer). The added check is the same as the one Emacs uses when
calling `save-buffer`. The fix may or may not need to be extended to
`racket-trim-requires` and `racket-save-requires` (I would guess not
really).