### PR TITLE
racket--version doesn't quote argument properly on Windows

### DIFF
--- a/racket-repl.el
+++ b/racket-repl.el
@@ -129,7 +129,7 @@ Never changes selected window."
 (defun racket--version ()
   "Get the `racket-racket-program' version as a string."
   (with-temp-buffer
-    (shell-command (concat racket-racket-program " -e '(version)'")
+    (shell-command (concat racket-racket-program " -e \"(version)\"")
                    (current-buffer))
     (eval (read (buffer-substring (point-min) (point-max))))))
 


### PR DESCRIPTION

![racket-mode](https://cloud.githubusercontent.com/assets/916582/11091742/ed747a70-88c0-11e5-8caf-38a2498d3110.png)

For windows support.