### PR TITLE
Add "lambda" and "define" to smart [ key forms

### DIFF
--- a/racket-common.el
+++ b/racket-common.el
@@ -326,7 +326,8 @@ With a prefix, insert the typed character as-is."
       ;; In addition to the obvious suspects with 'let' in the name,
       ;; handles forms like 'parameterize', 'with-handlers', 'for',
       ;; and 'for/fold' accumulator bindings.
-      (0 1 ,(rx (seq (or "for"
+      (0 1 ,(rx (seq (or "define"
+                         "for"
                          "for/list"
                          "for/vector"
                          "for/hash"
@@ -361,6 +362,7 @@ With a prefix, insert the typed character as-is."
                          "for*/sum"
                          "for*/product"
                          "fluid-let"
+                         "lambda"
                          "let"
                          "let*"
                          "let*-values"


### PR DESCRIPTION
This causes nested parens in argument lists to get [] instead of ().

Fixes #191.

I'm not completely sure that this is the Right Way, as there's lots of subtlety in the argument list syntax, but I figured I'd submit my test code rather than just describing it!