### PR TITLE
Font-lock performance; fixes #212

### DIFF
--- a/racket-custom.el
+++ b/racket-custom.el
@@ -25,6 +25,7 @@
 ;; a result, I'm defining `:tag`s AS IF `:prefix "racket-"` did work.
 ;; In other words defcustom of racket-foo-bar has a :tag "Foo Bar".
 
+(require 'rx)
 (require 'sh-script) ;for sh-heredoc-face
 
 (defgroup racket nil
@@ -180,6 +181,18 @@ or, use `racket-insert-lambda' to insert actual λ characters."
   :tag "Smart Open Bracket Enable"
   :type 'boolean
   :safe #'booleanp
+  :group 'racket-other)
+
+(defcustom racket-module-forms
+  (rx (syntax ?\()
+      (or (seq "module" (zero-or-one (any ?* ?+)))
+          "library"))
+  "Regexp for the start of a `module`-like form.
+Affects what `beginning-of-defun' will move to.
+This is safe to set as a file-local variable."
+  :tag "Top Level Forms"
+  :type 'string
+  :safe #'stringp
   :group 'racket-other)
 
 

--- a/racket-util.el
+++ b/racket-util.el
@@ -16,6 +16,8 @@
 ;; General Public License for more details. See
 ;; http://www.gnu.org/licenses/ for details.
 
+(require 'racket-custom)
+(require 'rx)
 (require 's)
 
 ;;; trace
@@ -66,35 +68,6 @@ strings."
                     keys)))
           spec)
     m))
-
-;;; racket--module-level-form-start
-
-(defun racket--module-level-form-start ()
-  "Start position of the module-level form point is within.
-
-A module-level form is the outermost form not nested in a Racket
-module form.
-
-If point is not within a module-level form, returns nil.
-
-If point is already exactly at the start of a module-level form,
--- i.e. on the opening ?\( -- returns nil.
-
-If point is within a string or comment, returns nil.
-
-This is NOT suitable for the variable `syntax-begin-function'
-because it (i) doesn't move point, and (ii) doesn't know how to
-find the start of a string or comment."
-  (save-excursion
-    (ignore-errors
-      (let ((result nil)
-            (parse-sexp-ignore-comments t))
-        (while (ignore-errors
-                 (goto-char (scan-lists (point) -1 1))
-                 (unless (looking-at (rx (syntax ?\() "module" (zero-or-one (any ?* ?+))))
-                   (setq result (point)))
-                 t))
-        result))))
 
 ;;; racket--buffer-file-name
 


### PR DESCRIPTION
- No longer use `racket--font-lock-extend-region` function. Instead:

  - For sexp comments, set match data for `font-lock-fontify-region` to
    use to do the highlighting and -- more importantly -- automatically
    apply the `'font-lock-multiline` property to the match region.

  - For `let`-like form identifiers, AFAICT we can't set match data. But
    we can apply the `'font-lock-multiline` ourselves to the region
    containing the bindings.

  In both cases, the `'font-lock-multiline` property is sufficient for
  both identification and rehighlighting. We no longer need to use
  `racket--module-level-form-start` to seek a good place for the
  font-lock region to begin. Which is good, because it could be
  painfully slow on longer files.

- Add a defcustom `racket-module-forms` -- a regular expression for
  module-like forms (and Scheme `library`) forms -- and use it in
  `racket--module-level-form-start`.

  Although `racket--module-level-form-start` is no longer for font-lock,
  it _is_ still used by `racket--beginning-of-defun-function`. In other
  words, now <kbd>C-M-a</kbd> or `M-x beginning-of-defun` will do the right thing
  in a Scheme `library` form, too.