### PR TITLE
Provide no command-line arguments in REPL

### DIFF
--- a/run.rkt
+++ b/run.rkt
@@ -25,7 +25,8 @@
     (file-stream-buffer-mode (current-output-port) 'none))
   (display (banner))
   (flush-output)
-  (parameterize ([error-display-handler our-error-display-handler])
+  (parameterize ([error-display-handler our-error-display-handler]
+                 [current-command-line-arguments '#()])
     (run rerun-default)))
 
 (define (run rr) ;rerun? -> void?


### PR DESCRIPTION
* run.rkt: Empty the vector of command-line arguments to match behaviour
  of DrRacket when evaluating modules which reference
  `current-command-line-arguments`.  Addresses #221.