### PR TITLE
Fix error using eval when REPL in separate frame

### DIFF
--- a/racket-edit.el
+++ b/racket-edit.el
@@ -253,7 +253,7 @@ To run <file>'s `test` submodule."
 (defun racket--shell (cmd)
   (let ((w (selected-window)))
     (save-buffer)
-    (let ((rw (get-buffer-window "*shell*")))
+    (let ((rw (get-buffer-window "*shell*" t)))
       (if rw
           (select-window rw)
         (other-window -1)))

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -78,7 +78,7 @@ Commands that don't want the REPL to be displayed can instead use
   (interactive "P")
   (racket--repl-ensure-buffer-and-process t)
   (unless noselect
-    (select-window (get-buffer-window racket--repl-buffer-name))))
+    (select-window (get-buffer-window racket--repl-buffer-name t))))
 
 (defconst racket--minimum-required-version "5.3.5"
   "The minimum version of Racket required by run.rkt.

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -316,7 +316,7 @@ Although they remain clickable they will be ignored by
 Keep original window selected."
   (display-buffer racket--repl-buffer-name)
   (save-selected-window
-    (select-window (get-buffer-window racket--repl-buffer-name))
+    (select-window (get-buffer-window racket--repl-buffer-name t))
     (comint-show-maximum-output)))
 
 ;;; Inline images in REPL


### PR DESCRIPTION
get-buffer-window will return nil if the window with the requested name
is not part of the current frame. I tend to use emacs frames instead of windows so that I can manage all of my windows emacs and non-emacs alike the same.