### PR TITLE
maybe-load-language-info: load cr-submod regardless of lang-info

### DIFF
--- a/run.rkt
+++ b/run.rkt
@@ -146,10 +146,10 @@
     (for ([config (in-list configs)])
       ((dynamic-require (vector-ref config 0)
                         (vector-ref config 1))
-       (vector-ref config 2)))
-    (define cr-submod `(submod ,path configure-runtime))
-    (when (module-declared? cr-submod)
-      (dynamic-require cr-submod #f))))
+       (vector-ref config 2))))
+  (define cr-submod `(submod ,path configure-runtime))
+  (when (module-declared? cr-submod)
+    (dynamic-require cr-submod #f)))
 
 (define (check-top-interaction)
   ;; Check that the lang defines #%top-interaction


### PR DESCRIPTION
Currently a configure-runtime submodule is only loaded if module->language-info can return something.  But you can have a configure-runtime submodule even if #%module-begin doesn't have a language-info syntax property.

This patch just moves the conditional configure-runtime submodule load out of the conditional that depends on module->language-info.