### PR TITLE
Add unicode for Union and Intersection.

### DIFF
--- a/racket-unicode-input-method.el
+++ b/racket-unicode-input-method.el
@@ -84,6 +84,8 @@ can turn it off by setting `input-method-highlight-flag' to nil via
 (quail-define-rules
  ;; Typed Racket
  ("All"              ["∀"])
+ ("Union"            ["U"])
+ ("Intersection"     ["∩"])
  ;; These would be nice except no such aliases provided by racket/contract.
  ;; ("->"               ["→"])
  ;; ("case->"           ["case→"])


### PR DESCRIPTION
After [this commit](https://github.com/racket/typed-racket/commit/aa1d36f44e0ef49d263cf53f97e578c1b58dca31), we have aliases for Union type and Intersection type.