### PR TITLE
Modified racket-repl--replace-images regex to capture windows paths

### DIFF
--- a/racket-repl.el
+++ b/racket-repl.el
@@ -386,7 +386,7 @@ images in 'racket-image-cache-dir'."
   (with-silent-modifications
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "\"#<Image: \\([-+./_0-9a-zA-Z]+\\)>\"" nil t)
+      (while (re-search-forward "\"#<Image: \\([-+./_0-9a-zA-Z:\\]+\\)>\"" nil t)
         ;; can't pass a filename to create-image because emacs might
         ;; not display it before it gets deleted (race condition)
         (let* ((file (match-string 1))

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -386,7 +386,7 @@ images in 'racket-image-cache-dir'."
   (with-silent-modifications
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "\"#<Image: \\([-+./_0-9a-zA-Z:\\]+\\)>\"" nil t)
+      (while (re-search-forward  "\"#<Image: \\(.+racket-image-.+\\.png\\)>\"" nil t)
         ;; can't pass a filename to create-image because emacs might
         ;; not display it before it gets deleted (race condition)
         (let* ((file (match-string 1))


### PR DESCRIPTION
This fixes the issue with viewing inline images in the repl on windows.

I don't have a Linux machine, so I can't test that the regex string still works on a different OS.