### PR TITLE
Make racket-run connect asynchronously.

### DIFF
--- a/racket-tests.el
+++ b/racket-tests.el
@@ -99,6 +99,8 @@
     (write-region code nil pathname nil 'no-wrote-file-message)
     (find-file pathname)
     (racket-run)
+    (while (not (comint-check-proc racket--repl-buffer-name))
+      (sit-for 0.5))
     ;; see expected prompt
     (with-racket-repl-buffer
       (should (racket-tests/see (concat "\n" name "\uFEFF> "))))


### PR DESCRIPTION
Other commands which need a connection to the racket command process
will still connect synchronously, but at least it's possible to make
the initial connection (which is usually the worst source of waiting)
without blocking the entire Emacs process.