### PR TITLE
Only remove overlays created by racket-mode

### DIFF
--- a/racket-edit.el
+++ b/racket-edit.el
@@ -139,7 +139,7 @@ of a file name to a list of submodule symbols. Otherwise, the
             (and (racket--buffer-file-name)
                  (not (file-exists-p (racket--buffer-file-name)))))
     (save-buffer))
-  (remove-overlays (point-min) (point-max) 'racket-uncovered-overlay)
+  (remove-overlays (point-min) (point-max) 'name 'racket-uncovered-overlay)
   (racket--invalidate-completion-cache)
   (racket--invalidate-type-cache)
   (racket--repl-eval ",run %S %s %s %s %S\n"


### PR DESCRIPTION
This is just a fix to the call remove-overlays. It expects a name /and/ a value to identify overlays. 
Right now racket-mode clears some overlays created by other minor modes as well.