### PR TITLE
Improve racket--version for speed

### DIFF
--- a/racket-repl.el
+++ b/racket-repl.el
@@ -147,13 +147,12 @@ Never changes selected window."
   "Get the `racket-program' version as a string."
   (with-temp-message "Checking Racket version..."
     (with-temp-buffer
-      (call-process racket-program
-                    nil                  ;infile: none
-                    t                    ;destination: current-buffer
-                    nil                  ;redisplay: no
-                    "-e"
-                    "(version)")
-      (eval (read (buffer-substring (point-min) (point-max)))))))
+      (call-process racket-program nil t nil "--version")
+      (goto-char (point-min))
+      ;; Welcome to Racket v6.12.
+      ;; Welcome to Racket v7.0.0.6.
+      (re-search-forward "[0-9]+\\(?:\\.[0-9]+\\)*")
+      (match-string 0))))
 
 (defun racket--require-version (at-least)
   "Raise a `user-error' unless Racket is version AT-LEAST."

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -151,8 +151,9 @@ Never changes selected window."
       (goto-char (point-min))
       ;; Welcome to Racket v6.12.
       ;; Welcome to Racket v7.0.0.6.
-      (re-search-forward "[0-9]+\\(?:\\.[0-9]+\\)*")
-      (match-string 0))))
+      (save-match-data
+        (re-search-forward "[0-9]+\\(?:\\.[0-9]+\\)*")
+        (match-string 0)))))
 
 (defun racket--require-version (at-least)
   "Raise a `user-error' unless Racket is version AT-LEAST."


### PR DESCRIPTION
`racket --version` is the fastest way to get the version

```
~ $ time racket -e '(version)'
"6.12"
        0.79 real         0.43 user         0.19 sys
~ $ time racket -l racket/base -e '(version)'
"6.12"
        0.09 real         0.06 user         0.02 sys
~ $ time racket --version
Welcome to Racket v6.12.
        0.02 real         0.01 user         0.01 sys
```