### PR TITLE
Improve `{beginning,end}-of-defun` and `add-log-current-defun-function`

### DIFF
--- a/racket-common.el
+++ b/racket-common.el
@@ -26,6 +26,7 @@
 (require 'racket-indent)
 (require 'racket-ppss)
 (require 'racket-util)
+(require 'subr-x)
 
 (declare-function racket-complete-at-point "racket-complete.el" (&optional predicate))
 

--- a/racket-common.el
+++ b/racket-common.el
@@ -26,7 +26,6 @@
 (require 'racket-indent)
 (require 'racket-ppss)
 (require 'racket-util)
-(require 'subr-x)
 
 (declare-function racket-complete-at-point "racket-complete.el" (&optional predicate))
 
@@ -650,7 +649,7 @@ the nested definitions."
       (when (looking-at racket--defun-start-rx)
         (throw 'found (point)))
       (goto-char orig)
-      (let ((parens (reverse (nth 9 (syntax-ppss (point))))))
+      (let ((parens (reverse (racket--ppss-parens (syntax-ppss (point))))))
         ;; If we are inside a nested sexp, try to move to the
         ;; innermost definition...
         (dolist (pos parens)
@@ -679,7 +678,7 @@ and assumes point is set up correctly."
        ;; scan errors happen if we are inside a nested definition and
        ;; move to the end.  Go outside the nested definition in this
        ;; case.
-       (let ((parens (nth 9 (syntax-ppss orig))))
+       (let ((parens (racket--ppss-parens (syntax-ppss orig))))
          (if (eq parens nil)
              (goto-char (point-max))
            (progn
@@ -696,12 +695,12 @@ string that represents the concatenation of the nested function names."
       (racket--beginning-of-defun-function))
     (when (looking-at racket--defun-start-rx)
       (let ((name (list (match-string-no-properties 2)))
-            (parens (reverse (nth 9 (syntax-ppss (point))))))
+            (parens (reverse (racket--ppss-parens (syntax-ppss (point))))))
         (dolist (pos parens)
           (goto-char pos)
           (when (looking-at racket--defun-start-rx)
             (push (match-string-no-properties 2) name)))
-        (string-join name " ")))))
+        (mapconcat #'identity name " ")))))
 
 (defun racket--module-level-form-start ()
   "Start position of the module-level form point is within.

--- a/racket-ppss.el
+++ b/racket-ppss.el
@@ -74,10 +74,6 @@ string began. When outside of strings and comments, this element
 is ‘nil’."
   (elt xs 8))
 
-(defun racket--ppss-parens (xs)
-  "The list of positions of currently open parens, outermost first."
-  (elt xs 9))
-
 (provide 'racket-ppss)
 
 ;; racket-ppss.el ends here

--- a/racket-ppss.el
+++ b/racket-ppss.el
@@ -74,6 +74,10 @@ string began. When outside of strings and comments, this element
 is ‘nil’."
   (elt xs 8))
 
+(defun racket--ppss-parens (xs)
+  "The list of positions of currently open parens, outermost first."
+  (elt xs 9))
+
 (provide 'racket-ppss)
 
 ;; racket-ppss.el ends here


### PR DESCRIPTION
The back end functions required to move forward and backward between functions have been updated to recognize nested constructs, such as method definitions inside classes or inner definitions in functions.

For the example below, `C-M-a` command will move from "start point 1" in the following order:

* inner-method2
* method2
* method1
* member-var1
* my-class%
* function1
* var1
* beginning of buffer

From "start-point2" it will navigate only the toplevel definitions and will not go inside the class methods.

I have also added a function to determine the current function name for the `C-x 4 a` command, and this function is also aware of inner definitions, for example at "start point 1", the function name would be "my-class% method2 inner-method2"

```racket
#lang racket

(define var1 'var1)
(define (function1) (void))

(define my-class%
  (class object%
    (init) (super-new)
    (define member-var1 'member-var1)
    (define/public (method1) (void))
    (define/public (method2)
      (define (inner-metod2)
        ;; example start point 1
        (void))
      (void))))

(define (function2)
  (define (inner-function2)
    ;; example start point 2
    (void))
  void)
```