### PR TITLE
Fix for Emacs freezing with company mode #359 introduced by f7d37a5

### DIFF
--- a/racket/elisp.rkt
+++ b/racket/elisp.rkt
@@ -58,15 +58,19 @@
                 "(1 t nil nil (a . b) ((1 . 2) (3 . 4)))"))
 
 (define (path->string/emacs p)
+  (when (string? p)
+    (set! p (string->path p)))
   (match (map path->string (explode-path p))
     [(list* (pregexp "([a-zA-z]:)\\\\" (list _ drive)) vs)
      #:when (eq? 'windows (system-type))
      (string-join (cons drive vs))]
-    [_ p]))
+    [_ (path->string p)]))
 
 (module+ test
   (when (eq? 'windows (system-type))
     (check-equal? (path->string/emacs "C:\\path\\to\\foo.rkt")
                   "C:/path/to/foo.rkt"))
   (check-equal? (path->string/emacs "/path/to/foo.rkt")
+                "/path/to/foo.rkt")
+  (check-equal? (path->string/emacs (string->path "/path/to/foo.rkt"))
                 "/path/to/foo.rkt"))


### PR DESCRIPTION
path->string/emacs returns a path if it was passed a path. This fix makes it return a string.