### PR TITLE
add some lispy support

### DIFF
--- a/racket-edit.el
+++ b/racket-edit.el
@@ -202,7 +202,7 @@ Please keep in mind the following limitations:
     (`nil nil)
     (str (racket--visit-symbol-definition str))))
 
-(defsubst racket-lispy-visit-symbol-definition (str)
+(defun racket-lispy-visit-symbol-definition (str)
   "Function called by lispy.el's `lispy-goto-symbol' for Racket
 symbol definition lookup."
   (racket--visit-symbol-definition str))

--- a/racket-edit.el
+++ b/racket-edit.el
@@ -200,14 +200,22 @@ Please keep in mind the following limitations:
   (interactive "P")
   (pcase (racket--symbol-at-point-or-prompt prefix "Visit definition of: ")
     (`nil nil)
-    (str (if (and (eq major-mode 'racket-mode)
-                  (not (equal (racket--repl-file-name+md5)
-                              (cons (racket--buffer-file-name t) (md5 (current-buffer)))))
-                  (y-or-n-p "Run current buffer first? "))
-             (racket--repl-run nil nil
-                               (lambda (_n/a)
-                                 (racket--do-visit-def-or-mod 'def str)))
-           (racket--do-visit-def-or-mod 'def str)))))
+    (str (racket--visit-symbol-definition str))))
+
+(defsubst racket-lispy-visit-symbol-definition (str)
+  "Function called by lispy.el's `lispy-goto-symbol' for Racket
+symbol definition lookup."
+  (racket--visit-symbol-definition str))
+
+(defun racket--visit-symbol-definition (str)
+  (if (and (eq major-mode 'racket-mode)
+           (not (equal (racket--repl-file-name+md5)
+                       (cons (racket--buffer-file-name t) (md5 (current-buffer)))))
+           (y-or-n-p "Run current buffer first? "))
+      (racket--repl-run nil nil
+                        (lambda (_n/a)
+                          (racket--do-visit-def-or-mod 'def str)))
+    (racket--do-visit-def-or-mod 'def str)))
 
 (defun racket-visit-module (&optional prefix)
   "Visit definition of module at point, e.g. net/url or \"file.rkt\".


### PR DESCRIPTION
- following instructions in #300, create public racket-mode function
  (`racket-lispy-visit-symbol-definition`) to be used by lispy
  - create helper function `racket--visit-symbol-definition` shared
    between `racket-lispy-visit-symbol-definition` and
    `racket-visit-definition`

- lispy code at https://github.com/abo-abo/lispy/compare/master...odanoburu:racket, I'll submit the PR to lispy after your approval
  - I'll be implementing the lispy functions as I need them, but the two functions in the link are the bare essentials I need