### PR TITLE
Make sending code as string the primitive REPL interaction (instead of as a region)

### DIFF
--- a/racket-repl.el
+++ b/racket-repl.el
@@ -549,8 +549,7 @@ Afterwards call `racket--repl-show-and-move-to-end'."
 (defun racket--send-region-to-repl (start end)
   "Internal function to send the region to the Racket REPL."
   (when (and start end)
-    (racket--send-to-repl (buffer-substring (region-beginning)
-                                            (region-end)))))
+    (racket--send-to-repl (buffer-substring start end))))
 
 (defun racket-send-region (start end)
   "Send the current region (if any) to the Racket REPL."


### PR DESCRIPTION
**Summary of Changes**
Currently, the primitive utility function that sends code to the Racket REPL for evaluation is one that extracts a region of interest and sends it via `comint-send-region`. In some cases though, it may be desirable to send code to the Racket REPL that isn't present in the buffer directly -- for instance, a modified version of code that is present in the buffer. In this case, we may need to send a string rather than a region.

Since string is a more elementary representation than a region, it may be preferable to use a string-based utility as the primitive. This PR adds this utility (which is mostly based on the existing region-based primitive), and modifies the current region-based functions to use the new string-based one.

**Context / example usecase:**
While working with some racket code I wanted to write a utility that would allow me to evaluate functions in the Racket REPL, and in certain cases "pretty print" the result if it is not of a type that renders usefully. For this purpose I needed to modify the actual code being evaluated with a wrapped conditional expression like `((let ([result ,<extracted-expression-from-the-buffer>]) (cond [(stream? result) (stream->list result)] ...))` and send this new string to the REPL. To avoid code duplication it seemed that sending a string to the REPL would be better provided by racket-mode than as a custom utility.
