### PR TITLE
Remove wrong keymapping.

### DIFF
--- a/racket-repl.el
+++ b/racket-repl.el
@@ -714,7 +714,6 @@ With prefix arg, open the N-th last shown image."
      ("C-M-q"           prog-indent-sexp)
      ("C-a"             comint-bol)
      ("C-w"             comint-kill-region)
-     ("[C-S-backspace]" comint-kill-whole-line)
      (")"               racket-insert-closing)
      ("]"               racket-insert-closing)
      ("}"               racket-insert-closing)


### PR DESCRIPTION
Reverts the keymapping "[C-S-backspace]" fixing the inserting of the leading square bracket "[" in the repl.