### PR TITLE
Add eldoc support via scribble/blueboxes

### DIFF
--- a/racket/command-server.rkt
+++ b/racket/command-server.rkt
@@ -13,7 +13,8 @@
          "interactions.rkt"
          "md5.rkt"
          "mod.rkt"
-         "util.rkt")
+         "util.rkt"
+         "scribble.rkt")
 
 (lazy-require
  ["commands/check-syntax.rkt" (check-syntax)]
@@ -166,6 +167,7 @@
     [`(describe ,str)                  (describe str)]
     [`(doc ,str)                       (doc str)]
     [`(type ,v)                        (type v)]
+    [`(blueboxes ,str)                 (blueboxes str)]
     [`(macro-stepper ,str ,into-base?) (macro-stepper str into-base?)]
     [`(macro-stepper/next)             (macro-stepper/next)]
     [`(requires/tidy ,reqs)            (requires/tidy reqs)]

--- a/racket/scribble.rkt
+++ b/racket/scribble.rkt
@@ -26,10 +26,8 @@
     (lambda (str)
       (define stx (namespace-symbol->identifier (string->symbol str)))
       (define tag (xref-binding->definition-tag xref stx 0))
-      (when tag
-        (define strs (fetch-blueboxes-strs tag #:blueboxes-cache cache))
-        (when strs
-          (string-replace (string-join (cdr strs) "\n") " " " "))))))
+      (define strs (and tag (fetch-blueboxes-strs tag #:blueboxes-cache cache)))
+      (and strs (string-replace (string-join (cdr strs) "\n") " " " ")))))
 
 ;;; Extract Scribble documentation as modified HTML suitable for
 ;;; Emacs' shr renderer.

--- a/racket/scribble.rkt
+++ b/racket/scribble.rkt
@@ -7,7 +7,9 @@
          racket/function
          racket/match
          racket/path
+         racket/string
          scribble/xref
+         scribble/blueboxes
          setup/xref
          (only-in xml
                   xml->xexpr
@@ -15,7 +17,19 @@
                   xexpr->string))
 
 (provide scribble-doc/html
-         binding->path+anchor)
+         binding->path+anchor
+         blueboxes)
+
+(define blueboxes
+  (let ([cache (make-blueboxes-cache #t)]
+        [xref (load-collections-xref)])
+    (lambda (str)
+      (define stx (namespace-symbol->identifier (string->symbol str)))
+      (define tag (xref-binding->definition-tag xref stx 0))
+      (when tag
+        (define strs (fetch-blueboxes-strs tag #:blueboxes-cache cache))
+        (when strs
+          (string-replace (string-join (cdr strs) "\n") " " " "))))))
 
 ;;; Extract Scribble documentation as modified HTML suitable for
 ;;; Emacs' shr renderer.

--- a/racket/scribble.rkt
+++ b/racket/scribble.rkt
@@ -8,6 +8,7 @@
          racket/match
          racket/path
          racket/string
+         racket/promise
          scribble/xref
          scribble/blueboxes
          setup/xref
@@ -21,12 +22,12 @@
          blueboxes)
 
 (define blueboxes
-  (let ([cache (make-blueboxes-cache #t)]
+  (let ([cache (delay (make-blueboxes-cache #t))]
         [xref (load-collections-xref)])
     (lambda (str)
       (define stx (namespace-symbol->identifier (string->symbol str)))
       (define tag (xref-binding->definition-tag xref stx 0))
-      (define strs (and tag (fetch-blueboxes-strs tag #:blueboxes-cache cache)))
+      (define strs (and tag (fetch-blueboxes-strs tag #:blueboxes-cache (force cache))))
       (and strs (string-replace (string-join (cdr strs) "\n") " " " ")))))
 
 ;;; Extract Scribble documentation as modified HTML suitable for


### PR DESCRIPTION
I noticed DrRacket's hover feature is built on https://docs.racket-lang.org/scribble/blueboxes.html, I think we can also try it for the eldoc support.