### PR TITLE
Use open as racket-images-system-viewer for macOS

### DIFF
--- a/racket-custom.el
+++ b/racket-custom.el
@@ -207,7 +207,9 @@ Defaults to a regexp ignoring all inputs of 0, 1, or 2 letters."
   :safe #'integerp
   :group 'racket-repl)
 
-(defcustom racket-images-system-viewer "display"
+(defcustom racket-images-system-viewer (if (eq system-type 'darwin)
+                                           "open"
+                                         "display")
   "Which system image viewer program to invoke upon M-x
  `racket-view-last-image'."
   :tag "Images System Viewer"


### PR DESCRIPTION
I notice `M-x racket-view-last-image` does not work for me until I change the value of `racket-images-system-viewer` to the open(1) command.