### PR TITLE
sexp comment fontification

### DIFF
--- a/racket/test/comments.rkt
+++ b/racket/test/comments.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+(require rackunit)
+(require syntax/macro-testing)
+
+;; proof we have nothing up our sleeve
+(check-exn exn:fail:syntax? (λ () (convert-syntax-error one)))
+(check-exn exn:fail:syntax? (λ () (convert-syntax-error two)))
+
+;; examples for comment fontification
+
+(check-eq? 'one ; comment
+           'one)
+
+#;(a b c ;comment
+     d e f)
+
+(check-eq? 'two #; one 'two)
+
+(check-eq? 'three #; #; one two 'three)
+
+(check-eq? 'three
+           #;
+           #;
+           one
+           two
+           'three)
+
+(check-eq? 'three
+           #; ; comment
+           #; ; comment
+           one
+           two
+           'three)
+
+(check-eq? 'three
+           #; ; comment
+           #; ; comment
+           (list one)
+           (list two)
+           'three)
+
+(check-eq? 'three
+           #;
+           ; comment
+           #;
+           #|
+           comment
+           |#
+           one
+           (a b c ; comment
+              d e f)
+           'three)
+
+(check-eq? 'one ; #;
+           'one)

--- a/racket/test/comments.rkt
+++ b/racket/test/comments.rkt
@@ -1,11 +1,6 @@
 #lang racket/base
 
 (require rackunit)
-(require syntax/macro-testing)
-
-;; proof we have nothing up our sleeve
-(check-exn exn:fail:syntax? (λ () (convert-syntax-error one)))
-(check-exn exn:fail:syntax? (λ () (convert-syntax-error two)))
 
 ;; examples for comment fontification
 


### PR DESCRIPTION
This PR should resolve the sexp comment fontification issues noted in #432, however it may introduce additional issues. I have not tested this yet beyond checking comments.rkt to see if the fontification is correct, but wanted to get the implementation out there for review and comparison given the discussion thread in #432. Once `racket-forward-sexp` is implemented it is ok to continue to mark sexp comments as quotes syntactically since the behavior is more in line with what users would expect when navigating.