### PR TITLE
Recognize srcloc structs in REPL

### DIFF
--- a/racket-repl.el
+++ b/racket-repl.el
@@ -952,9 +952,18 @@ instead of looking at point."
               (any ?\: ?\.)
               (group-n 3 (+ digit)))
           #'racket--adjust-group-1 2 3)
-     ;; Any path struct
-     (list (rx "#<path:" (group-n 1 (+? (not (any ?\>)))) ?\>)
-           #'racket--adjust-group-1 nil nil 0)))
+    ;; Any path struct
+    (list (rx "#<path:" (group-n 1 (+? (not (any ?\>)))) ?\>)
+          #'racket--adjust-group-1 nil nil 0)
+    ;; Any (srcloc path line column ...) struct
+    (list (rx "(" "srcloc" (+ space)
+              ;; path
+              "\"" (group-n 1 (+? any)) "\""
+              ;; line
+              (+ space) (group-n 2 (+ digit))
+              ;; column
+              (+ space) (group-n 3 (+ digit)))
+          #'racket--adjust-group-1 2 3 0 1)))
   ;; Persistent history
   (setq-local comint-input-filter #'racket-repl--input-filter)
   (make-directory racket--config-dir t)


### PR DESCRIPTION
We extend compilation-error-regexp-alist with a recognizer for srcloc
structs that get linkified and highlighted as INFO. This won't
distract you from normal work but will improve quality of life when
you work with parsers or readers that track source locations the
"Racket way". This tiny patch lets you immediately jump to
corresponding location.