### PR TITLE
Add `racket-xp-helpdesk` and `racket-repl-helpdesk`

### DIFF
--- a/doc/generate.el
+++ b/doc/generate.el
@@ -62,6 +62,7 @@
     racket-xp-visit-definition
     racket-xp-describe
     racket-xp-documentation
+    racket-xp-helpdesk
     "Run"
     racket-run
     racket-run-and-switch-to-repl
@@ -69,6 +70,7 @@
     racket-repl
     racket-repl-describe
     racket-repl-documentation
+    racket-repl-helpdesk
     racket-repl-visit-definition
     racket-racket
     racket-profile
@@ -167,6 +169,7 @@
     racket-browse-url-function
     racket-xp-after-change-refresh-delay
     racket-xp-highlight-unused-regexp
+    racket-documentation-search
     "REPL variables"
     racket-repl-buffer-name-function
     racket-history-filter-regexp

--- a/racket-custom.el
+++ b/racket-custom.el
@@ -161,6 +161,23 @@ an underline, which is a common convention."
   :safe #'stringp
   :group 'racket-xp)
 
+(defcustom racket-documentation-search
+  "https://docs.racket-lang.org/search/index.html?q=%s"
+  "Where `racket-xp-helpdesk' and `racket-repl-helpdesk' should
+look for the search page.  If the value of this variable is
+'local, open the search page from the local documentation.
+Otherwise, use the URL given by this variable.
+
+This variable should contain a string recognizable by `format',
+with %s at the point at which to insert the identifier to look up
+in the help desk.  Apart from %s, the string should be a properly
+encoded URL."
+  :tag "Where to look for the help desk"
+  :type '(choice (string :tag "URL")
+                 (const :tag "Local" 'local))
+  :safe (lambda (val) (or (stringp val) (eq val 'local)))
+  :group 'racket-xp)
+
 ;;; REPL
 
 (defgroup racket-repl nil

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -936,6 +936,7 @@ by the file module -- not locals or definitions in submodules."
      ("C-c C-e r"       racket-expand-region)
      ("M-C-y"           racket-insert-lambda)
      ("C-c C-d"         racket-repl-documentation)
+     ("C-c C-s"         racket-repl-helpdesk)
      ("C-c C-."         racket-repl-describe)
      ("M-."             racket-repl-visit-definition)
      ("C-M-."           racket-visit-module)

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -898,6 +898,26 @@ instead of looking at point."
                                                  `(doc namespace ,str)
                                                  #'racket-browse-url))))
 
+(defun racket-repl-helpdesk (&optional prefix)
+  "Show the Search Manuals page with the identifier at point.
+
+If `racket-documentation-search' is set to 'local, opens the
+Search Manuals page from the local documentation.  Otherwise,
+opens the page given by the URL in `racket-documentation-search'.
+
+Like `racket-repl-documentation', given a prefix, prompts for the
+identifier, in which case it assumes definitions in or imported
+by the file module -- not locals or definitions in submodules."
+  (interactive "P")
+  (pcase (racket--symbol-at-point-or-prompt prefix "Documentation for: "
+					    racket--repl-namespace-symbols)
+    ((and (pred stringp) symb)
+     (pcase racket-documentation-search
+       ((and (pred stringp) url)
+        (browse-url (format url symb)))
+       ('local
+        (call-process racket-program nil 0 nil "-l" "raco" "doc" symb))))))
+
 ;;; racket-repl-mode
 
 (defvar racket-repl-mode-map

--- a/racket-xp.el
+++ b/racket-xp.el
@@ -58,7 +58,8 @@ everything. If you find that too \"noisy\", set this to nil.")
    `(("C-c #"     ,racket-xp-control-c-hash-keymap)
      ("M-."       ,#'racket-xp-visit-definition)
      ("C-c C-."   ,#'racket-xp-describe)
-     ("C-c C-d"   ,#'racket-xp-documentation))))
+     ("C-c C-d"   ,#'racket-xp-documentation)
+     ("C-c C-s"   ,#'racket-xp-helpdesk))))
 
 (easy-menu-define racket-xp-mode-menu racket-xp-mode-map
   "Menu for `racket-xp-mode'."

--- a/racket-xp.el
+++ b/racket-xp.el
@@ -480,6 +480,26 @@ definitions in submodules."
                            `(doc ,(buffer-file-name) ,str)
                            #'racket-browse-url))))))
 
+(defun racket-xp-helpdesk (&optional prefix)
+  "Show the Search Manuals page with the identifier at point.
+
+If `racket-documentation-search' is set to 'local, opens the
+Search Manuals page from the local documentation.  Otherwise,
+opens the page given by the URL in `racket-documentation-search'.
+
+Like `racket-xp-documentation', given a prefix, prompts for the
+identifier, in which case it assumes definitions in or imported
+by the file module -- not locals or definitions in submodules."
+  (interactive "P")
+  (pcase (racket--symbol-at-point-or-prompt prefix "Documentation for: "
+					    racket--xp-binding-completions)
+    ((and (pred stringp) symb)
+     (pcase racket-documentation-search
+       ((and (pred stringp) url)
+        (browse-url (format url symb)))
+       ('local
+        (call-process racket-program nil 0 nil "-l" "raco" "doc" symb))))))
+
 (defun racket-xp--forward-use (amt)
   "When point is on a use, go AMT uses forward. AMT may be negative.
 


### PR DESCRIPTION
This PR adds two functions to search identifiers (or strings) in the Search Manuals page.  This corresponds to the "Search in the Help Desk" functionality in DrRacket.  These functions mostly exploit the preexisting function `search` in `racket/commands/help.rkt`.

These PR also adds two customizable variables to control the behavior of these functions.