### PR TITLE
Fix a missing closing parenthesis in the doc

### DIFF
--- a/doc/racket-mode.texi
+++ b/doc/racket-mode.texi
@@ -1049,7 +1049,7 @@ and/or slow, in your @code{racket-xp-mode-hook} you may disable them:
 	  (lambda ()
 	    (remove-hook 'pre-redisplay-functions
 			 #'racket-xp-pre-redisplay
-			 t))
+			 t)))
 @end lisp
 
 The remaining features discussed below will still work.

--- a/racket-xp.el
+++ b/racket-xp.el
@@ -128,7 +128,7 @@ and/or slow, in your `racket-xp-mode-hook' you may disable them:
             (lambda ()
               (remove-hook 'pre-redisplay-functions
                            #'racket-xp-pre-redisplay
-                           t))
+                           t)))
 #+END_SRC
 
 The remaining features discussed below will still work.


### PR DESCRIPTION
This commit adds a missing parenthesis in the documentation of `racket-xp-mode`.

Prior to this commit, I regenerated the `racket-mode.texi` following the recommendation in [CONTRIBUTING.md](https://github.com/greghendershott/racket-mode/blob/29afd2544a2f14bf29f3e542f6177579d0ae581f/CONTRIBUTING.md#docgenerateel). But the newly generated `racket-mode.texi` was full of modifications not related to my parenthesis insertion. So I reverted it back to its initial state and simply edited it manually to only add the missing closing parenthesis.

Is the manual edition good for you, or you prefer me to amend this commit with the generated `racket-mode.texi`?