### PR TITLE
Add support for `project.el' in `racket-repl-buffer-name-project'

### DIFF
--- a/racket-repl-buffer-name.el
+++ b/racket-repl-buffer-name.el
@@ -47,6 +47,7 @@ The \"project\" is determined by trying, in order:
 
 - `projectile-project-root'
 - `vc-root-dir'
+- `project-current'
 - `file-name-directory'"
   (interactive)
   (let* ((dir  (file-name-directory (racket--buffer-file-name)))
@@ -54,6 +55,8 @@ The \"project\" is determined by trying, in order:
                         (projectile-project-root dir))
                    (and (fboundp 'vc-root-dir)
                         (vc-root-dir))
+                   (and (fboundp 'project-current)
+                        (cdr (project-current nil dir)))
                    dir))
          (name (format "*Racket REPL <%s>*" root)))
     (setq-local racket-repl-buffer-name name)))


### PR DESCRIPTION
`project.el` is bundled with emacs by default; this adds support for it.

I've used an `fboundp`, in the case that someone is using an older emacs version or
has specifically unbound the symbol.