### PR TITLE
Only rename identifiers that are textually equal

### DIFF
--- a/racket-xp.el
+++ b/racket-xp.el
@@ -551,9 +551,10 @@ If point is instead on a definition, then go to its first use."
       (dolist (marker-pair marker-pairs)
         (let ((beg (marker-position (nth 0 marker-pair)))
               (end (marker-position (nth 1 marker-pair))))
-          (delete-region beg end)
-          (goto-char beg)
-          (insert new-id))))
+          (when (string= (buffer-substring-no-properties beg end) old-id)
+            (delete-region beg end)
+            (goto-char beg)
+            (insert new-id)))))
     (goto-char (marker-position point-marker))
     (racket-xp-annotate)))
 


### PR DESCRIPTION
It is possible to have an arrow between two identifiers that are not
textually equivalent (definitely possible in DrRacket, and theoretically
possible in Racket Mode).

In the above event, renaming one identifier should not change the other.

See also racket/drracket#415 for a similar fix in DrRacket, and
racket/racket#3391 which would start to make Racket Mode behave
incorrectly. In particular, with the above PR, renaming
the identifier `a` in the following program should not rename
`all-defined-out` as well.

    #lang racket
    (provide (all-defined-out))
    (define a 1)