### PR TITLE
Make racket-browse-url functions compatible with eww

### DIFF
--- a/racket-browse-url.el
+++ b/racket-browse-url.el
@@ -53,7 +53,7 @@ customize."
          (file (make-temp-file "racket-browse-url-" nil ".html"))
          (html (format "<html><head><meta http-equiv=\"refresh\" content=\"0;url=%s\" /></head></html>" url)))
     (write-region html nil file nil 'no-wrote-file-message)
-    (browse-url file)))
+    (browse-url url)))
 
 (provide 'racket-browse-url)
 


### PR DESCRIPTION
Emac's `eww` browser opens urls such as `/path/to/a/file.html` as `https://path/to/a/file.html`. This causes the documentation functions not to open the correct documentation page (such address doesn't exist).


Instead, the url provided to `eww` must be in the form `file:///path/to/a/file.html`. I have manually tested that this format is also compatible with `browse-url-default-macosx-browser`.


This PR modifies the argument in the `browse-url` call in `racket-browse-url-using-temporary-file` to use `url` (which already has the correct format) instead of `file`.