### PR TITLE
fix anchor handling

### DIFF
--- a/racket-browse-url.el
+++ b/racket-browse-url.el
@@ -41,9 +41,10 @@ you do not need to use this. You can customize the variable
 or indeed whatever you want."
   (let* ((url  (if (string-match ".*://" url) url (concat "file://" url)))
          (file (make-temp-file "racket-browse-url-" nil ".html"))
+         (file-uri (concat "file://" file))
          (html (format "<html><head><meta http-equiv=\"refresh\" content=\"0;url=%s\" /></head></html>" url)))
     (write-region html nil file nil 'no-wrote-file-message)
-    (browse-url file)))
+    (browse-url file-uri)))
 
 (provide 'racket-browse-url)
 


### PR DESCRIPTION
sadly, `eww`, which follows RFC 1630 and RFC 1738, doesn't support anchors for `file://`
uris, but this change brings back the feature for other browsers.

closes #541 

this fix should also (partially) take care of #530