### PR TITLE
Added support for remote racket

### DIFF
--- a/racket-custom.el
+++ b/racket-custom.el
@@ -138,6 +138,15 @@ and `racket-repl-documentation' should look for the search page.
   :safe (lambda (val) (or (stringp val) (eq val 'local)))
   :group 'racket)
 
+(defcustom racket--rkt-remote-source-dir
+  "/tmp/racket-mode-source/"
+  "Path to dir of our Racket source files in the remote host. The
+actual remote host is determined at the calling site. See
+`racket--rkt-get-source-dir'."
+  :tag "Remote root to copy racket files."
+  :type 'directory
+  :group 'racket)
+
 ;;; Xp Mode
 
 (defgroup racket-xp nil

--- a/racket/repl.rkt
+++ b/racket/repl.rkt
@@ -128,8 +128,8 @@
 (define listener
   (tcp-listen 0  ;choose port dynamically, a.k.a. "ephemeral" port
               64
-              #f ;reuse? not recommended for ephemeral ports
-              "127.0.0.1"))
+              #t ;reuse? not recommended for ephemeral ports
+              "0.0.0.0"))
 (define repl-tcp-port-number
   (let-values ([(_loc-addr port _rem-addr _rem-port) (tcp-addresses listener #t)])
     (log-racket-mode-info "TCP port ~v chosen for REPL sessions" port)


### PR DESCRIPTION
When a racket session is created in a file visiting a remote server
via tramp the racket process is created in the remote server. If this
is the case the racket code running in the server is copied to the
remote server (if it is not there already). Said code is also modified
to accept connections from externa sources (security concern?).

This  is my solutiuon to issue #552 .