### PR TITLE
racket-util.el: racket--rkt-source-dir - const -> var

### DIFF
--- a/racket-util.el
+++ b/racket-util.el
@@ -93,7 +93,7 @@ When installed as a package, this can be found from the variable
 `load-file-name'. When developing interactively, get it from the
 .el buffer file name.")
 
-(defconst racket--rkt-source-dir
+(defvar racket--rkt-source-dir
   (expand-file-name "./racket/" racket--el-source-dir)
   "Path to dir of our Racket source files. ")
 


### PR DESCRIPTION
in case a user wants to put racket-mode's racket (source & bytecode)
files into a different directory this will provide a easier
customization path

Signed-off-by: Maciej Barć <xgqt@gentoo.org>