### PR TITLE
Use "setin " instead of "in " to produce ∈.

### DIFF
--- a/racket-unicode-input-method.el
+++ b/racket-unicode-input-method.el
@@ -142,7 +142,7 @@ can turn it off by setting `input-method-highlight-flag' to nil."
  ("vee "                ["∨"])
  ("wedge "              ["∧"])
  ("follows "            ["∘"])
- ("in "                 ["∈"])
+ ("setin "              ["∈"])
  ("ni "                 ["∋"])
  ("notin "              ["∉"])
  ("sqsubset "           ["⊏"])


### PR DESCRIPTION
Since "in" is both a very commonly used word and a common suffix of english words, 
the replacement "in " to "∈" quickly becomes annoying when writing normal text when 
when the `racket-unicode-input-method` is enabled.

I propose to replace "in " with "setin " that way the  it is not neccessary to
keep toggling `racket-unicode-input-method` on-and-off again.

The downside is that most users will expect "in " since "\in" is used in TeX.