### PR TITLE
add declare-function to keep compiler happy

### DIFF
--- a/racket-browse-url.el
+++ b/racket-browse-url.el
@@ -18,6 +18,7 @@
 
 (require 'racket-custom)
 (require 'racket-cmd)
+(require 'racket-back-end)
 
 (defun racket-browse-url (url &rest args)
   (when url

--- a/racket-company-doc.el
+++ b/racket-company-doc.el
@@ -18,6 +18,7 @@
 
 (require 'shr)
 (require 'racket-describe)
+(require 'racket-back-end)
 
 (defun racket--company-doc-buffer (how str)
   (pcase (racket--cmd/await (racket--repl-session-id)
@@ -44,6 +45,7 @@
            (mains (racket--scribble-mains-for-anchor mains anchor))
            (dom   `(div () ,@mains))
            (dom   (racket--walk-dom dom)))
+      (ignore tramp-verbose)
       (save-excursion
         (let ((shr-use-fonts nil)
               (shr-external-rendering-functions `((span . ,#'racket-render-tag-span)))

--- a/racket-describe.el
+++ b/racket-describe.el
@@ -24,6 +24,7 @@
 (require 'racket-visit)
 (require 'racket-scribble)
 (require 'racket-browse-url)
+(require 'racket-back-end)
 ;; Don't (require 'racket-repl). Mutual dependency. Instead:
 (declare-function 'racket--repl-session-id "racket-repl")
 (autoload         'racket--repl-session-id "racket-repl")

--- a/racket-doc.el
+++ b/racket-doc.el
@@ -20,6 +20,7 @@
 (require 'racket-cmd)
 (require 'racket-custom)
 (require 'racket-util)
+(require 'racket-back-end)
 (declare-function racket--repl-session-id "racket-repl.el" ())
 
 (defun racket--doc-assert-local-back-end ()

--- a/racket-eldoc.el
+++ b/racket-eldoc.el
@@ -17,6 +17,7 @@
 ;; http://www.gnu.org/licenses/ for details.
 
 (require 'racket-cmd)
+(require 'racket-back-end)
 
 (defun racket--do-eldoc (how repl-session-id)
   (and (racket--cmd-open-p)

--- a/racket-logger.el
+++ b/racket-logger.el
@@ -20,6 +20,7 @@
 (require 'rx)
 (require 'racket-custom)
 (require 'racket-repl)
+(require 'racket-back-end)
 
 ;; Need to define this before racket-logger-mode
 (defvar racket-logger-mode-map

--- a/racket-mode.el
+++ b/racket-mode.el
@@ -128,6 +128,9 @@
     ["Start Faster" racket-mode-start-faster]
     ["Customize..." customize-mode]))
 
+(declare-function racket-call-racket-repl-buffer-name-function "racket-repl-buffer-name" ())
+(autoload        'racket-call-racket-repl-buffer-name-function "racket-repl-buffer-name")
+
 ;;;###autoload
 (define-derived-mode racket-mode prog-mode
   "Racket"

--- a/racket-profile.el
+++ b/racket-profile.el
@@ -18,6 +18,7 @@
 
 (require 'racket-repl)
 (require 'racket-util)
+(require 'racket-back-end)
 
 (defvar-local racket--profile-project-root nil)
 (defvar-local racket--profile-results nil)

--- a/racket-repl.el
+++ b/racket-repl.el
@@ -29,6 +29,7 @@
 (require 'racket-util)
 (require 'racket-visit)
 (require 'racket-cmd)
+(require 'racket-back-end)
 (require 'comint)
 (require 'compile)
 (require 'easymenu)
@@ -37,6 +38,9 @@
 (require 'rx)
 (require 'xref)
 (require 'semantic/symref/grep)
+
+(defvar racket--back-end-auth-token)
+(declare-function  racket--what-to-run-p "racket-common" (v))
 
 ;; Don't (require 'racket-debug). Mutual dependency. Instead:
 (declare-function  racket--debug-send-definition "racket-debug" (beg end))

--- a/racket-stepper.el
+++ b/racket-stepper.el
@@ -22,6 +22,7 @@
 (require 'racket-custom)
 (require 'racket-repl)
 (require 'racket-util)
+(require 'racket-back-end)
 
 ;; Need to define this before racket-stepper-mode
 (defvar racket-stepper-mode-map

--- a/racket-xp.el
+++ b/racket-xp.el
@@ -27,6 +27,7 @@
 (require 'racket-visit)
 (require 'racket-show)
 (require 'racket-xp-complete)
+(require 'racket-back-end)
 (require 'easymenu)
 (require 'imenu)
 (require 'rx)
@@ -34,6 +35,7 @@
 (require 'xref)
 
 (declare-function racket-complete-at-point "racket-edit.el")
+(declare-function racket-browse-file-url "racket-browse-url" (path anchor))
 
 ;; TODO: Expose as a defcustom? Or even as commands to turn on/off?
 ;; Also note there are really 3 categories here: 'local 'import


### PR DESCRIPTION
In emacs 29 the byte compiler fails if a function is used without being
defined or having a declare-function expression associated with it. This
causes make compile to fail.