### PR TITLE
Fix scope bug with expanded syntax cacher

### DIFF
--- a/racket/syntax.rkt
+++ b/racket/syntax.rkt
@@ -70,7 +70,7 @@
               (path-string? (syntax-source e))
               (complete-path? (syntax-source e))
               (file-exists? (syntax-source e)))
-         (define expanded-stx (expand e))
+         (define expanded-stx (expand-syntax e))
          (define-values (code-str digest) (file->string+digest (syntax-source e)))
          (cache-set! (syntax-source e) code-str e expanded-stx digest)
          (orig-eval expanded-stx)]


### PR DESCRIPTION
When the eval-handler is called for a use of `eval-syntax`, avoid adding scopes to the syntax by using `expand-syntax` rather than `expand`.

Here's a file that demonstrates the effect:

```
#lang racket/base

(namespace-require 'racket/base)
(eval '(define x 5))

; Ensure `id` has a source location to trigger racket-mode's expanded syntax cacher.
(define id (datum->syntax #f 'x #'here))

; Works because `eval` adds the namespace outside-edge scope.
(eval id)

; Should be unbound; `eval-syntax` should not add the scope.
; In racket-mode it instead evaluates to 5.
(eval-syntax id)
```

I don't understand the expanded syntax cacher well enough to know whether the other uses of `expand` should be changed as well; changing just this occurrence fixed the problem I had.
