### PR TITLE
better default unused face

### DIFF
--- a/racket-custom.el
+++ b/racket-custom.el
@@ -528,7 +528,7 @@ ignore POS. Examples: `racket-show-echo-area' and
   "Error Face")
 
 (defface-racket racket-xp-unused-face
-  '((t (:strike-through t)))
+  '((t (:underline (:color "yellow" :style wave))))
   "Face `racket-xp-mode' uses to highlight unused requires or definitions."
   "Unused Face")
 


### PR DESCRIPTION
The default unused face interacts poorly with scheme's extensive use of `kebab-case`. Reading the code

```
            (define-values (open-end-line open-end-col open-end-pos) (port-next-location in))
```

in which `open-end-line` and `open-end-col` were marked undefined, I found it hard to see how many variables there were, since the face strikethrough covered the kebab dashes. I mean, I was pretty sure it was 3 total, but it was annoying.

You can always customize this (I already have), but better defaults are better.