### PR TITLE
racket-doc: Dont try to expand racket-program as directory

### DIFF
--- a/racket-doc.el
+++ b/racket-doc.el
@@ -58,7 +58,7 @@ Centralizes how to issue doc command and handle response correctly."
 
 (defun racket--search-doc-locally (str)
   (racket--doc-assert-local-back-end)
-  (call-process (expand-file-name racket-program)
+  (call-process racket-program
                 nil ;INFILE: none
                 0   ;DESTINATION: discard/don't wait
                 nil ;DISPLAY: none


### PR DESCRIPTION
Expanding `racket-program` expands the path in whatever the current directory is unless `racket-program` already happens to be an absolute path.