### PR TITLE
Introduce a new envvar to set a longer timeout for Debian buildds

### DIFF
--- a/test/racket-tests.el
+++ b/test/racket-tests.el
@@ -40,7 +40,16 @@
 (defconst ci-p (getenv "CI")
   "Is there an environment variable saying we're running on CI?")
 
-(defconst racket-tests/timeout (if ci-p 60 10))
+(defconst debian-buildd-p (getenv "DEBIAN_BUILDD")
+  "Is there an environment variable saying we're running on Debian buildd?")
+
+(defconst racket-tests/timeout
+  (cond
+   ;; Some Debian supported architectures are very slow and requires
+   ;; a longer timeout for some of the tests to finish.
+   (debian-buildd-p 900)
+   (ci-p 60)
+   (t 10)))
 
 (defun racket-tests/type (typing)
   (let ((blink-matching-paren nil)) ;suppress "Matches " messages

--- a/test/racket-tests.el
+++ b/test/racket-tests.el
@@ -269,7 +269,7 @@ c.rkt. Visit each file, racket-run, and check as expected."
 
 (ert-deftest racket-tests/profile ()
   "Exercise `racket-profile'."
-  (skip-unless (not ci-p))
+  (skip-unless (not (or ci-p debian-buildd-p)))
   (message "racket-tests/profile")
   (racket-tests/with-back-end-settings
     (let* ((path (make-temp-file "test" nil ".rkt"))
@@ -726,11 +726,11 @@ want to use the value of `racket-program' at run time."
       dur)))
 
 (ert-deftest racket-tests/indent-speed-1 ()
-  (skip-unless (not ci-p))
+  (skip-unless (not (or ci-p debian-buildd-p)))
   (should (< (racket-tests/indent-time "example/class-internal.rkt") 10)))
 
 (ert-deftest racket-tests/indent-speed-2 ()
-  (skip-unless (not ci-p))
+  (skip-unless (not (or ci-p debian-buildd-p)))
   (should (< (racket-tests/indent-time "example/core.scm") 10)))
 
 ;;; Font-lock


### PR DESCRIPTION
* Some of the Debian supported architectures are very slow and requires a longer timeout for some of the tests to finish.