### PR TITLE
Restructure Makefile to make it easier to exclude tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,10 @@ test-elisp:
       -f ert-run-tests-batch-and-exit
 
 # Files to test using `raco test -x`.
-test-x-rkt-files := $(wildcard ./racket/*.rkt) $(wildcard ./racket/commands/*.rkt)
+test-x-rkt-files := \
+	$(wildcard ./racket/*.rkt) \
+	$(wildcard ./racket/commands/*.rkt) \
+	$(wildcard ./test/racket/*.rkt)
 # Exclude hash-lang.rkt because it will fail to eval on older Rackets;
 # normally we only dynamic-require it. Furthermore its tests are in
 # ./test/racket/hash-lang-test.rkt.
@@ -73,7 +76,6 @@ test-x-rkt-files := $(filter-out ./racket/hash-lang.rkt, $(test-x-rkt-files))
 
 test-racket:
 	$(RACKET) -l raco test -x $(test-x-rkt-files)
-	$(RACKET) -l raco test ./test/racket/
 
 test-slow:
 	$(RACKET) -l raco test --submodule slow-test ./racket/imports.rkt


### PR DESCRIPTION
* Include all test files in test-x-rkt-files using wildcard
* Drop the rule to build on ./test/racket directory

More on motivation: `./test/racket/hash-lang-test.rkt` fails when running under Debian sbuild as it tries to open a display :0, and it cannot work under sbuild.  Restructuring the Makefile this way makes it easier to exclude a test using `filter-out`.