### PR TITLE
Support command line arguments to racket-program/backend

### DIFF
--- a/doc/racket-mode.texi
+++ b/doc/racket-mode.texi
@@ -3147,7 +3147,18 @@ Delete the ``compiled'' directories made by @ref{racket-mode-start-faster}.
 @node racket-program
 @subsection racket-program
 
-Pathname of the Racket executable.
+Pathname of the Racket executable or command line to launch it.
+
+@itemize
+@item
+If the value of this variable is a string, it will be interpreted as a
+simple command without arguments.
+
+@item
+If it is a list of strings, the first element will be taken to be the
+executable, and the rest of the list command line arguments to pass to
+it before any other arguments.
+@end itemize
 
 Note that a back end configuration can override this with a
 non-nil @code{racket-program} property list value. See
@@ -4195,9 +4206,9 @@ are a few examples.
 
     ;; 4. For example's sake, assume for buffers visiting
     ;; /ssh:headless:~/gui-project/ we want :racket-program instead
-    ;; to be "xvfb-run racket".
+    ;; to be '("xvfb-run" "racket").
     (racket-add-back-end "/ssh:headless:~/gui-project/"
-                         :racket-program "xvfb-run racket")
+                         :racket-program '("xvfb-run" "racket"))
 @end lisp
 
 If you use various versions of Racket by setting PATH values via

--- a/racket-back-end.el
+++ b/racket-back-end.el
@@ -454,12 +454,13 @@ a possibly slow remote connection."
 (defun racket--back-end-args->command (back-end racket-command-args)
   "Given RACKET-COMMAND-ARGS, prepend path to racket for BACK-END."
   (if (racket--back-end-local-p back-end)
-      (cons (or (executable-find (or (plist-get back-end :racket-program)
-                                     racket-program))
-                (error
-                 "Cannot executable-find Racket:\n  racket-program: %S\n  exec-path: %S"
-                 racket-program
-                 exec-path))
+      (cons (let ((racket-program (or (plist-get back-end :racket-program)
+                                      racket-program)))
+              (or (executable-find racket-program)
+                  (error
+                   "Cannot executable-find Racket:\n  racket-program: %S\n  exec-path: %S"
+                   racket-program
+                   exec-path)))
             racket-command-args)
     (pcase-let ((`(,host ,user ,port ,_name)
                  (racket--file-name->host+user+port+name

--- a/racket-custom.el
+++ b/racket-custom.el
@@ -40,12 +40,20 @@
 (defvar racket--winp (eq 'windows-nt system-type))
 
 (defcustom racket-program (if racket--winp "Racket.exe" "racket")
-  "Pathname of the Racket executable.
+  "Pathname of the Racket executable or command line to launch it.
+
+- If the value of this variable is a string, it will be interpreted as a
+  simple command without arguments.
+
+- If it is a list of strings, the first element will be taken to be the
+  executable, and the rest of the list command line arguments to pass to
+  it before any other arguments.
 
 Note that a back end configuration can override this with a
 non-nil `racket-program` property list value. See
 `racket-add-back-end'."
-  :type '(file :must-match t)
+  :type '(choice (string)
+                 (repeat string))
   :risky t)
 
 (make-obsolete-variable 'racket-command-port nil "2020-04-25")

--- a/racket-doc.el
+++ b/racket-doc.el
@@ -60,11 +60,15 @@ Centralizes how to issue doc command and handle response correctly."
 
 (defun racket--search-doc-locally (str)
   (racket--doc-assert-local-back-end)
-  (call-process racket-program
-                nil ;INFILE: none
-                0   ;DESTINATION: discard/don't wait
-                nil ;DISPLAY: none
-                "-l" "raco" "docs" str))
+  (let ((command (if (stringp racket-program)
+                     (list racket-program)
+                   racket-program)))
+    (apply #'call-process `(,(car command)
+                            nil ;INFILE: none
+                            0   ;DESTINATION: discard/don't wait
+                            nil ;DISPLAY: none
+                            ,@(cdr command)
+                            "-l" "raco" "docs" ,str))))
 
 (provide 'racket-doc)
 

--- a/racket-shell.el
+++ b/racket-shell.el
@@ -11,6 +11,7 @@
 (require 'racket-custom)
 (require 'racket-util)
 (require 'shell)
+(require 'subr-x)
 (require 'term)
 
 (defun racket-racket ()
@@ -34,11 +35,17 @@ variable `racket-shell-or-terminal-function'."
 
 (defun racket--shell-or-terminal (args)
   (racket--save-if-changed)
-  (let* ((exe (shell-quote-argument
-               (if (file-name-absolute-p racket-program)
-                   (expand-file-name racket-program) ;handle e.g. ~/
-                 racket-program)))
-         (cmd (concat exe " " args))
+  (let* ((command (if (stringp racket-program)
+                      (list racket-program)
+                    racket-program))
+         (program (car command))
+         (exe (shell-quote-argument
+               (if (file-name-absolute-p program)
+                   (expand-file-name program) ;handle e.g. ~/
+                 program)))
+         (flags (mapcar (lambda (x) (shell-quote-argument x))
+                        (cdr command)))
+         (cmd (concat exe " " (string-join flags " ") args))
          (win (selected-window)))
     (funcall racket-shell-or-terminal-function cmd)
     (select-window win)))


### PR DESCRIPTION
The documentation already had examples of configurations like

```elisp
(racket-add-back-end "/ssh:headless:~/gui-project/"
                     :racket-program "xvfb-run racket")
```

This would (accidentally?) work for remote backends, because the way the SSH
command is invoked ends up applying shell word splitting on the program.

However, when I wanted to use this locally something like this:

```elisp
(racket-add-backend "/project/"
                    :racket-program "podman
                                     run --rm --interactive
                                     --volume=/project/:/project/:z
                                     --workdir=/project/
                                     docker.io/racket/racket/8.9-full"
                                     "racket")
```

This wouldn't work because the `executable-find' call would try to find the path
to an executable with that full string as a name.

We could in theory apply word splitting on this string ourselves, but I think
it's more common for modes to have a `*-flags' variable in these cases, so I add
that here.