### PR TITLE
repair racket-project-root

### DIFF
--- a/racket-util.el
+++ b/racket-util.el
@@ -118,7 +118,9 @@ The \"project\" is determined by trying, in order:
         (and (fboundp 'vc-root-dir)
              (vc-root-dir))
         (and (fboundp 'project-current)
-             (cdr (project-current nil dir)))
+             (let ((pr (project-current nil dir)))
+               (and (fboundp 'project-root)
+                    (project-root pr))))
         dir)))
 
 (defun racket--edit-mode-p ()


### PR DESCRIPTION
The representation of a project seems to have changed.  `cdr (project nil dir))` returns `(VC <dir>)` rather than the directory wanted. `project-root` hides the details and gives us the desirable result.